### PR TITLE
Add TLDR Legal as a recommendation for Licensing

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ members or found helpful for managing open source projects and offices.
 - [FOSSID](https://fossid.com) - A comprehensive commercial scanner for licenses and vulnerabilities.  Knowledgebase covers 78M+ repositories and 600B+ snippets. Includes detailed snippet scanning to detect the license on fragments and copied/pasted code, even if the open source license is not explicitly or correctly declared.
 - [DependencyTrack](https://github.com/DependencyTrack/dependency-track) - Dependency-Track is an intelligent Component Analysis platform that allows organizations to identify and reduce risk in the software supply chain
 - [ScanOSS](https://www.scanoss.com/) - Scan your codebase for snippets and plagerism from large knowledge base of open source projects.  Designed to integrate with CI/CD and modern IDEs, to "start left" to do continuous validation instead of one report at the end.  Product itself is fully open source.  
+- [TLDRLegal](https://tldrlegal.com/) - TLDRLegal summarizes the most common open source licenses in plain English. Provides a quick reference for what a user can, cannot, and must do according to the license terms. 
 
 ## Localization and Internationalization
 


### PR DESCRIPTION
TLDRlegal is a helpful quick reference for the most common open source language licenses. Useful for those that are newer to OSS licensing. 

Signed-off-by: Renisha Nellums <r.nellums@gmail.com>